### PR TITLE
feat: feature/36 Daixando nossos controllers administrativos mais DRY

### DIFF
--- a/app/controllers/administrate/articles_controller.rb
+++ b/app/controllers/administrate/articles_controller.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module Administrate
-  class ArticlesController < ApplicationController
-    before_action :authenticate_admin!
+  class ArticlesController < AdministrateController
+    
     before_action :set_article, only: [:show, :edit, :update, :destroy, :destroy_cover_image]
 
-    layout "administrate"
 
     # GET /articles or /articles.json
     def index

--- a/app/controllers/administrate/dashboards_controller.rb
+++ b/app/controllers/administrate/dashboards_controller.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
+
 module Administrate
-  class DashboardsController < ApplicationController
-    before_action :authenticate_admin!
-    layout "administrate"
+  class DashboardsController < AdministrateController
     def index; end
   end
 end

--- a/app/controllers/administrate_controller.rb
+++ b/app/controllers/administrate_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class AdministrateController < ApplicationController
+  before_action :authenticate_admin!
+  layout "administrate"
+end


### PR DESCRIPTION
- Ao aplicar essas práticas, você pode reduzir a repetição de códigos nos controllers administrativos, tornando-os mais limpos, fáceis de manter e menos propensos a erros.