### PR TITLE
feat: feature/46 Associações no Rails - belongs_to

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,8 @@ class Article < ApplicationRecord
   extend FriendlyId
   friendly_id(:title, use: :slugged)
 
+  belongs_to :category
+
   has_one_attached :cover_image do |attachable|
     attachable.variant(:thumb, resize_to_limit: [325, 205])
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Category < ApplicationRecord
+end

--- a/db/migrate/20240413224234_create_categories.rb
+++ b/db/migrate/20240413224234_create_categories.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:categories, id: :uuid) do |t|
+      t.string(:name)
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240413224636_add_category_to_article.rb
+++ b/db/migrate/20240413224636_add_category_to_article.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCategoryToArticle < ActiveRecord::Migration[7.1]
+  def change
+    add_reference(:articles, :category, foreign_key: true, type: :uuid)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_095019) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_13_224636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -61,7 +61,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_095019) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
+    t.uuid "category_id"
+    t.index ["category_id"], name: "index_articles_on_category_id"
     t.index ["slug"], name: "index_articles_on_slug", unique: true
+  end
+
+  create_table "categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
@@ -89,4 +97,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_095019) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "articles", "categories"
 end


### PR DESCRIPTION
 - No Rails, "belongs_to" é uma associação que estabelece uma relação entre dois modelos, indicando que um objeto de um modelo pertence a um objeto de outro modelo.